### PR TITLE
Fix error with set serializer for createClient

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -98,8 +98,8 @@ class PhpRedisConnector implements Connector
                 $client->setOption(Redis::OPT_READ_TIMEOUT, $config['read_timeout']);
             }
 
-            if (! empty($options['serializer'])) {
-                $client->setOption(Redis::OPT_SERIALIZER, $options['serializer']);
+            if (! empty($config['serializer'])) {
+                $client->setOption(Redis::OPT_SERIALIZER, $config['serializer']);
             }
 
             if (! empty($config['scan'])) {


### PR DESCRIPTION
https://github.com/laravel/framework/pull/31182
Mistake in variable name in method Illuminate\Redis\Connectors\PhpRedisConnector::createClient.